### PR TITLE
Fix getting cwd without permission

### DIFF
--- a/btb_manager_telegram/utils.py
+++ b/btb_manager_telegram/utils.py
@@ -88,10 +88,13 @@ def get_binance_trade_bot_process() -> Optional[psutil.Process]:
         bot_path = os.path.normpath(os.path.join(os.getcwd(), settings.ROOT_PATH))
 
     for proc in psutil.process_iter():
-        if (
-            name in proc.name() or name in " ".join(proc.cmdline())
-        ) and proc.cwd() == bot_path:
-            return proc
+        try:
+            if (
+                name in proc.name() or name in " ".join(proc.cmdline())
+            ) and proc.cwd() == bot_path:
+                return proc
+        except psutil.AccessDenied:
+            continue
 
 
 def find_and_kill_binance_trade_bot_process():


### PR DESCRIPTION
# Setup
In a scenario when there are several BTB instances running by different users, the manager will fail to find corresponding process
because getting cwd may result in access denied due to lacking permissions to read other user proc cwd info.
```python
psutil.AccessDenied: psutil.AccessDenied (pid=17482, name='python')
```
```bash
$ ps aux | grep binance
otheruser   17482 34.6  9.1 779932 92032 pts/4    Sl+  May03 190:25 python -m binance_trade_bot
myuser      17893 41.0  9.7 792144 97884 pts/0    Sl+  May03 189:19 python -m binance_trade_bot
```

# Solution 
The proposed fix is just to ignore `psutil.AccessDenied` exception, treating it as a guarantee that it is not the process we are looking for.