### PR TITLE
Remove numpy dependency

### DIFF
--- a/btb_manager_telegram/utils.py
+++ b/btb_manager_telegram/utils.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 import psutil
 import telegram
 import yaml
-from numpy import format_float_positional
 from telegram import Bot
 
 from btb_manager_telegram import logger, scheduler, settings
@@ -218,7 +217,7 @@ def update_reminder(self, message):
 
 
 def format_float(num):
-    return format_float_positional(num, trim="-")
+    return f"{num:0.8f}".rstrip("0").rstrip(".")
 
 
 def get_custom_scripts_keyboard():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 colorama==0.4.4
 configparser==5.0.2
-numpy
 psutil==5.8.0
 python-telegram-bot==13.5
 pyyaml==5.4.1


### PR DESCRIPTION
For something as simple as float formatting with fixed width and no trailing zeroes `numpy` is an overkill, especially if we don't use it for anything else. I put a max width after dot of 8, because it is the precision for most numbers on binance.