### PR TITLE
Use scout multiplier from user.cfg instead of hard coded

### DIFF
--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -180,6 +180,7 @@ def current_ratios():
                 config = ConfigParser()
                 config.read_file(cfg)
                 bridge = config.get("binance_user_config", "bridge")
+                scout_multiplier = config.get("binance_user_config", "scout_multiplier")
 
             con = sqlite3.connect(db_file_path)
             cur = con.cursor()
@@ -202,7 +203,7 @@ def current_ratios():
             # Get prices and ratios of all alt coins
             try:
                 cur.execute(
-                    f"""SELECT sh.datetime, p.to_coin_id, sh.other_coin_price, ( ( ( current_coin_price / other_coin_price ) - 0.001 * 5 * ( current_coin_price / other_coin_price ) ) - sh.target_ratio ) AS 'ratio_dict' FROM scout_history sh JOIN pairs p ON p.id = sh.pair_id WHERE p.from_coin_id='{current_coin}' AND p.from_coin_id = ( SELECT alt_coin_id FROM trade_history ORDER BY datetime DESC LIMIT 1) ORDER BY sh.datetime DESC LIMIT ( SELECT count(DISTINCT pairs.to_coin_id) FROM pairs WHERE pairs.from_coin_id='{current_coin}');"""
+                    f"""SELECT sh.datetime, p.to_coin_id, sh.other_coin_price, ( ( ( current_coin_price / other_coin_price ) - 0.001 * '{scout_multiplier}' * ( current_coin_price / other_coin_price ) ) - sh.target_ratio ) AS 'ratio_dict' FROM scout_history sh JOIN pairs p ON p.id = sh.pair_id WHERE p.from_coin_id='{current_coin}' AND p.from_coin_id = ( SELECT alt_coin_id FROM trade_history ORDER BY datetime DESC LIMIT 1) ORDER BY sh.datetime DESC LIMIT ( SELECT count(DISTINCT pairs.to_coin_id) FROM pairs WHERE pairs.from_coin_id='{current_coin}');"""
                 )
                 query = cur.fetchall()
 


### PR DESCRIPTION
There are a couple of hard coded things in the BTB manager which can also be read from the `user.cfg`, i.e. the `scout_multiplier`.

Closes #88 