### PR TITLE
fix: only select enabled coins for ratios

### DIFF
--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -203,7 +203,7 @@ def current_ratios():
             # Get prices and ratios of all alt coins
             try:
                 cur.execute(
-                    f"""SELECT sh.datetime, p.to_coin_id, sh.other_coin_price, ( ( ( current_coin_price / other_coin_price ) - 0.001 * '{scout_multiplier}' * ( current_coin_price / other_coin_price ) ) - sh.target_ratio ) AS 'ratio_dict' FROM scout_history sh JOIN pairs p ON p.id = sh.pair_id WHERE p.from_coin_id='{current_coin}' AND p.from_coin_id = ( SELECT alt_coin_id FROM trade_history ORDER BY datetime DESC LIMIT 1) ORDER BY sh.datetime DESC LIMIT ( SELECT count(DISTINCT pairs.to_coin_id) FROM pairs WHERE pairs.from_coin_id='{current_coin}');"""
+                    f"""SELECT sh.datetime, p.to_coin_id, sh.other_coin_price, ( ( ( current_coin_price / other_coin_price ) - 0.001 * '{scout_multiplier}' * ( current_coin_price / other_coin_price ) ) - sh.target_ratio ) AS 'ratio_dict' FROM scout_history sh JOIN pairs p ON p.id = sh.pair_id WHERE p.from_coin_id='{current_coin}' AND p.from_coin_id = ( SELECT alt_coin_id FROM trade_history ORDER BY datetime DESC LIMIT 1) ORDER BY sh.datetime DESC LIMIT ( SELECT count(DISTINCT pairs.to_coin_id) FROM pairs JOIN coins ON coins.symbol = pairs.to_coin_id WHERE coins.enabled = 1 AND pairs.from_coin_id='{current_coin}');"""
                 )
                 query = cur.fetchall()
 


### PR DESCRIPTION
Hi there,

I noticed a strange output with some doubled coins when pressing the "Current ratios" button after i removed some coins from my list:

![image](https://user-images.githubusercontent.com/6589385/118410051-dda2a580-b68d-11eb-8202-0544f1390a1a.png)

Then i exported the db and looked into the sql statment for the ratio selection and noticed that there where entries from the previous scout tick:

![image](https://user-images.githubusercontent.com/6589385/118410114-2195aa80-b68e-11eb-84ef-f74c1a73c99a.png)

The LIMIT part of the sql statement does not ignore the disabled coins. So i added the check if the coin is enabled.

Greetings :)