### PR TITLE
Enhanced logging of profits to get a deeper understanding/control of …

### DIFF
--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -91,11 +91,11 @@ def current_value():
 
                 return_rate_1_day, return_rate_7_day = 0, 0
                 balance_1_day, btc_price_1_day, balance_7_day, btc_price_7_day = 0, 0, 0, 0
-                if query_1_day is not None:
+                if query_1_day is not None and btc_price != 0:
                     balance_1_day, btc_price_1_day = query_1_day
                     return_rate_1_day = round((balance * btc_price - balance_1_day * btc_price_1_day) / (balance_1_day * btc_price_1_day) * 100, 2)
 
-                if query_7_day is not None:
+                if query_7_day is not None and btc_price != 0:
                     balance_7_day, btc_price_7_day = query_7_day
                     return_rate_7_day = round((balance * btc_price - balance_7_day * btc_price_7_day) / (balance_7_day * btc_price_7_day) * 100, 2)
             except Exception as e:

--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -59,6 +59,22 @@ def current_value():
                     f"""SELECT balance, usd_price, btc_price, datetime FROM 'coin_value' WHERE coin_id = '{current_coin}' ORDER BY datetime DESC LIMIT 1;"""
                 )
                 query = cur.fetchone()
+                cur.execute(
+                    f"""SELECT cv.balance, cv.btc_price
+                        FROM coin_value as cv
+                        WHERE cv.coin_id = (SELECT th.alt_coin_id FROM trade_history as th WHERE th.datetime > DATETIME ('now', '-1 day') AND th.selling = 0 ORDER BY th.datetime ASC LIMIT 1)
+                        AND cv.datetime > (SELECT th.datetime FROM trade_history as th WHERE th.datetime > DATETIME ('now', '-1 day') AND th.selling = 0 ORDER BY th.datetime ASC LIMIT 1)
+                        ORDER BY cv.datetime ASC LIMIT 1;"""
+                )
+                query_1_day = cur.fetchone()
+                cur.execute(
+                    f"""SELECT cv.balance, cv.btc_price
+                        FROM coin_value as cv
+                        WHERE cv.coin_id = (SELECT th.alt_coin_id FROM trade_history as th WHERE th.datetime > DATETIME ('now', '-7 day') AND th.selling = 0 ORDER BY th.datetime ASC LIMIT 1)
+                        AND cv.datetime > (SELECT th.datetime FROM trade_history as th WHERE th.datetime > DATETIME ('now', '-7 day') AND th.selling = 0 ORDER BY th.datetime ASC LIMIT 1)
+                        ORDER BY cv.datetime ASC LIMIT 1;"""
+                )
+                query_7_day = cur.fetchone()
                 if query is None:
                     return [
                         f"❌ No information about *{current_coin}* available in the database\.",
@@ -72,6 +88,16 @@ def current_value():
                 if btc_price is None:
                     btc_price = 0
                 last_update = datetime.strptime(last_update, "%Y-%m-%d %H:%M:%S.%f")
+
+                return_rate_1_day, return_rate_7_day = 0, 0
+                balance_1_day, btc_price_1_day, balance_7_day, btc_price_7_day = 0, 0, 0, 0
+                if query_1_day is not None:
+                    balance_1_day, btc_price_1_day = query_1_day
+                    return_rate_1_day = round((balance * btc_price - balance_1_day * btc_price_1_day) / (balance_1_day * btc_price_1_day) * 100, 2)
+
+                if query_7_day is not None:
+                    balance_7_day, btc_price_7_day = query_7_day
+                    return_rate_7_day = round((balance * btc_price - balance_7_day * btc_price_7_day) / (balance_7_day * btc_price_7_day) * 100, 2)
             except Exception as e:
                 logger.error(
                     f"❌ Unable to fetch current coin information from database: {e}",
@@ -89,14 +115,13 @@ def current_value():
                     f"\nLast update: `{last_update.strftime('%H:%M:%S %d/%m/%Y')}`\n\n"
                     f"*Current coin {current_coin}:*\n"
                     f"\t\- Balance: `{format_float(balance)}` *{current_coin}*\n"
-                    f"\t\- Current coin exchange rate: `{format_float(usd_price)}` *USD*/*{current_coin}*\n"
+                    f"\t\- Exchange rate purchased: `{format_float(buy_price / alt_amount)}` *{bridge}*/*{current_coin}* \n"
+                    f"\t\- Exchange rate now:           `{format_float(usd_price)}` *USD*/*{current_coin}*\n"
+                    f"\t\- *Change in value*: `{round((balance * usd_price - buy_price) / buy_price * 100, 2)}` *%*'\n"
                     f"\t\- Value in *USD*: `{round(balance * usd_price, 2)}` *USD*\n"
                     f"\t\- Value in *BTC*: `{format_float(balance * btc_price)}` *BTC*\n\n"
-                    f"_Initially bought for_ `{round(buy_price, 2)}` *{bridge}*\n"
-                    f"_Exchange rate when purchased:_ `{format_float(buy_price / alt_amount)}` *{bridge}*/*{current_coin}*\n"
-                    f"{f'*Change in value*: `{round((balance * usd_price - buy_price) / buy_price * 100, 2)}` *%*' if bridge in ['USDT', 'BUSD'] else ''}".replace(
-                        ".", "\."
-                    )
+                    f"1 day change BTC: `{return_rate_1_day}` %\n"
+                    f"7 days change BTC: `{return_rate_7_day}` %\n"
                 ]
                 message = telegram_text_truncator(m_list)
                 con.close()
@@ -130,21 +155,26 @@ def check_progress():
             # Get progress information
             try:
                 cur.execute(
-                    """SELECT th1.alt_coin_id AS coin, th1.alt_trade_amount AS amount, th1.crypto_trade_amount AS priceInUSD,(th1.alt_trade_amount - ( SELECT th2.alt_trade_amount FROM trade_history th2 WHERE th2.state = 'COMPLETE' AND th2.alt_coin_id = th1.alt_coin_id AND th1.datetime > th2.datetime AND th2.selling = 0 ORDER BY th2.datetime DESC LIMIT 1)) AS change, datetime FROM trade_history th1 WHERE th1.state = 'COMPLETE' AND th1.selling = 0 ORDER BY th1.datetime DESC LIMIT 15"""
+                    """SELECT th1.alt_coin_id AS coin, th1.alt_trade_amount AS amount, th1.crypto_trade_amount AS priceInUSD,(th1.alt_trade_amount - ( SELECT th2.alt_trade_amount FROM trade_history th2 WHERE th2.state = 'COMPLETE' AND th2.alt_coin_id = th1.alt_coin_id AND th1.datetime > th2.datetime AND th2.selling = 0 ORDER BY th2.datetime DESC LIMIT 1)) AS change, (SELECT th2.datetime FROM trade_history th2 WHERE th2.state = 'COMPLETE' AND th2.alt_coin_id = th1.alt_coin_id AND th1.datetime > th2.datetime AND th2.selling = 0 ORDER BY th2.datetime DESC LIMIT 1) AS pre_last_trade_date, datetime FROM trade_history th1 WHERE th1.state = 'COMPLETE' AND th1.selling = 0 ORDER BY th1.datetime DESC LIMIT 15"""
                 )
                 query = cur.fetchall()
 
                 # Generate message
                 m_list = ["Current coin amount progress:\n\n"]
                 for coin in query:
-                    last_trade_date = datetime.strptime(
+                    pre_last_trade_date = datetime.strptime(
                         coin[4], "%Y-%m-%d %H:%M:%S.%f"
-                    ).strftime("%H:%M:%S %d/%m/%Y")
+                    )
+                    last_trade_date = datetime.strptime(
+                        coin[5], "%Y-%m-%d %H:%M:%S.%f"
+                    )
+                    time_passed = last_trade_date - pre_last_trade_date
+                    last_trade_date = last_trade_date.strftime("%H:%M:%S %d/%m/%Y")
                     m_list.append(
                         f"*{coin[0]}*\n"
                         f"\t\- Amount: `{format_float(coin[1])}` *{coin[0]}*\n"
                         f"\t\- Price: `{round(coin[2], 2)}` *USD*\n"
-                        f"\t\- Change: {f'`{format_float(coin[3])}` *{coin[0]}*' if coin[3] is not None else f'`{coin[3]}`'}\n"
+                        f"\t\- Change: {f'`{format_float(coin[3])}` *{coin[0]}* `{round(coin[3] / (coin[1] - coin[3]) * 100, 2)}` *%* in the last {time_passed.days} days, {time_passed.seconds // 3600} hours' if coin[3] is not None else f'`{coin[3]}`'}\n"
                         f"\t\- Trade datetime: `{last_trade_date}`\n\n".replace(
                             ".", "\."
                         )

--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -90,14 +90,29 @@ def current_value():
                 last_update = datetime.strptime(last_update, "%Y-%m-%d %H:%M:%S.%f")
 
                 return_rate_1_day, return_rate_7_day = 0, 0
-                balance_1_day, btc_price_1_day, balance_7_day, btc_price_7_day = 0, 0, 0, 0
+                balance_1_day, btc_price_1_day, balance_7_day, btc_price_7_day = (
+                    0,
+                    0,
+                    0,
+                    0,
+                )
                 if query_1_day is not None and btc_price != 0:
                     balance_1_day, btc_price_1_day = query_1_day
-                    return_rate_1_day = round((balance * btc_price - balance_1_day * btc_price_1_day) / (balance_1_day * btc_price_1_day) * 100, 2)
+                    return_rate_1_day = round(
+                        (balance * btc_price - balance_1_day * btc_price_1_day)
+                        / (balance_1_day * btc_price_1_day)
+                        * 100,
+                        2,
+                    )
 
                 if query_7_day is not None and btc_price != 0:
                     balance_7_day, btc_price_7_day = query_7_day
-                    return_rate_7_day = round((balance * btc_price - balance_7_day * btc_price_7_day) / (balance_7_day * btc_price_7_day) * 100, 2)
+                    return_rate_7_day = round(
+                        (balance * btc_price - balance_7_day * btc_price_7_day)
+                        / (balance_7_day * btc_price_7_day)
+                        * 100,
+                        2,
+                    )
             except Exception as e:
                 logger.error(
                     f"❌ Unable to fetch current coin information from database: {e}",
@@ -117,7 +132,7 @@ def current_value():
                     f"\t\- Balance: `{format_float(balance)}` *{current_coin}*\n"
                     f"\t\- Exchange rate purchased: `{format_float(buy_price / alt_amount)}` *{bridge}*/*{current_coin}* \n"
                     f"\t\- Exchange rate now:           `{format_float(usd_price)}` *USD*/*{current_coin}*\n"
-                    f"\t\- *Change in value*: `{round((balance * usd_price - buy_price) / buy_price * 100, 2)}` *%*'\n"
+                    f"\t\- *Change in value*: `{round((balance * usd_price - buy_price) / buy_price * 100, 2)}` *%*\n"
                     f"\t\- Value in *USD*: `{round(balance * usd_price, 2)}` *USD*\n"
                     f"\t\- Value in *BTC*: `{format_float(balance * btc_price)}` *BTC*\n\n"
                     f"1 day change BTC: `{return_rate_1_day}` %\n"
@@ -162,9 +177,7 @@ def check_progress():
                 # Generate message
                 m_list = ["Current coin amount progress:\n\n"]
                 for coin in query:
-                    last_trade_date = datetime.strptime(
-                        coin[5], "%Y-%m-%d %H:%M:%S.%f"
-                    )
+                    last_trade_date = datetime.strptime(coin[5], "%Y-%m-%d %H:%M:%S.%f")
                     if coin[4] is None:
                         pre_last_trade_date = datetime.strptime(
                             coin[5], "%Y-%m-%d %H:%M:%S.%f"
@@ -180,7 +193,7 @@ def check_progress():
                         f"*{coin[0]}*\n"
                         f"\t\- Amount: `{format_float(coin[1])}` *{coin[0]}*\n"
                         f"\t\- Price: `{round(coin[2], 2)}` *USD*\n"
-                        f"\t\- Change: {f'`{format_float(coin[3])}` *{coin[0]}* `{round(coin[3] / (coin[1] - coin[3]) * 100, 2)}` *%* in the last {time_passed.days} days, {time_passed.seconds // 3600} hours' if coin[3] is not None else f'`{coin[3]}`'}\n"
+                        f"\t\- Change: {f'`{format_float(coin[3])}` *{coin[0]}* `{round(coin[3] / (coin[1] - coin[3]) * 100, 2)}` *%* in {time_passed.days} days, {time_passed.seconds // 3600} hours' if coin[3] is not None else f'`{coin[3]}`'}\n"
                         f"\t\- Trade datetime: `{last_trade_date}`\n\n".replace(
                             ".", "\."
                         )

--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -162,12 +162,18 @@ def check_progress():
                 # Generate message
                 m_list = ["Current coin amount progress:\n\n"]
                 for coin in query:
-                    pre_last_trade_date = datetime.strptime(
-                        coin[4], "%Y-%m-%d %H:%M:%S.%f"
-                    )
                     last_trade_date = datetime.strptime(
                         coin[5], "%Y-%m-%d %H:%M:%S.%f"
                     )
+                    if coin[4] is None:
+                        pre_last_trade_date = datetime.strptime(
+                            coin[5], "%Y-%m-%d %H:%M:%S.%f"
+                        )
+                    else:
+                        pre_last_trade_date = datetime.strptime(
+                            coin[4], "%Y-%m-%d %H:%M:%S.%f"
+                        )
+
                     time_passed = last_trade_date - pre_last_trade_date
                     last_trade_date = last_trade_date.strftime("%H:%M:%S %d/%m/%Y")
                     m_list.append(


### PR DESCRIPTION
…the gains and profits of this bot

I always had the struggle to understand the actual profit/gains of this bot. This is why I enhanced the logging and output of it. I need gains in percentage not in total numbers. I always want to see different types of gains, like in BTC (which would be the most neutral one, as USDT pair changes) and on different time scales, like 1 day or 7 days.

Current value outputs like this:
```
Last update: 20:20:09 25/05/2021

Current coin ONT:
 - Balance: 2008.57 ONT
 - Exchange rate purchased: 1.1723 USDT/ONT 
 - Exchange rate now:       1.0771 USD/ONT
 - Change in value: -8.12 %'
 - Value in USD: 2163.43 USD
 - Value in BTC: 0.05746519 BTC

1 day change BTC: -4.7 %
7 days change BTC: 11.11 %
```

Progress outputs like this:
```
ONT
 - Amount: 2008.57 ONT
 - Price: 2354.65 USD
 - Change: 148.86 ONT 8.0 % in the last 4 days, 7 hours
 - Trade datetime: 00:10:02 25/05/2021
```