### PR TITLE
Adds except for psutils zombieprocess

### DIFF
--- a/btb_manager_telegram/utils.py
+++ b/btb_manager_telegram/utils.py
@@ -94,6 +94,8 @@ def get_binance_trade_bot_process() -> Optional[psutil.Process]:
                 return proc
         except psutil.AccessDenied:
             continue
+        except psutil.ZombieProcess:
+            continue
 
 
 def find_and_kill_binance_trade_bot_process():


### PR DESCRIPTION
Per title, these 2 lines stop interactions like check bot status and start/stop being rendered inactive by an errant zombie process somewhere on the system.