### PR TITLE
Was not working with python 3.10, specify python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9
 
 WORKDIR ./
 


### PR DESCRIPTION
Hi, i was trying to deploy with docker and dint work on python v 3.10, as it was not specified what version it was i specified v 3.9