### PR TITLE
Fix Trade History command, swap Sold and Bought.

### DIFF
--- a/btb_manager_telegram/buttons.py
+++ b/btb_manager_telegram/buttons.py
@@ -460,9 +460,9 @@ def trade_history():
 
                         trade_details = i18n_format(
                             "history.sold_bought",
-                            sold_trade=i18n_format("history.bought")
+                            sold_trade=i18n_format("history.sold")
                             if trade[2]
-                            else i18n_format("history.sold"),
+                            else i18n_format("history.bought"),
                             amount1=trade[4],
                             coin1=trade[0],
                             amount2=trade[5],


### PR DESCRIPTION
Text "Sold" and "Bought" was in wrong order. So I swap two text in right order.